### PR TITLE
Refactor: Replace relm4 with gtk4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,52 +3,16 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cairo-rs"
@@ -84,12 +48,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,24 +62,6 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -270,25 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "gio"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +236,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -531,31 +452,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "js-sys"
-version = "0.3.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "libadwaita"
@@ -595,21 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,50 +508,6 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pango"
@@ -738,58 +579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "relm4"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bae902de22fd92e62641f047975abf228573425b9b8de175e8ab5b6cda10379"
-dependencies = [
- "flume",
- "fragile",
- "futures",
- "gtk4",
- "libadwaita",
- "once_cell",
- "relm4-css",
- "relm4-macros",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "relm4-components"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3155d84425d33cdc62929ed2c79bfcfdcb2fff6340c5f7041ed24b56577c9d57"
-dependencies = [
- "once_cell",
- "relm4",
- "tracker",
-]
-
-[[package]]
-name = "relm4-css"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dbe7a114855a22618f0e13595ce6b3f165478c13c2dfc4f4f99614da105797"
-
-[[package]]
-name = "relm4-macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175fce497fc6f11dde7ea56daa30ff7ad29a534bbc209d59d766659c880ba5f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,22 +588,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -887,15 +664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,20 +703,6 @@ name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
-
-[[package]]
-name = "tokio"
-version = "1.47.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
-dependencies = [
- "backtrace",
- "io-uring",
- "libc",
- "mio",
- "pin-project-lite",
- "slab",
-]
 
 [[package]]
 name = "toml"
@@ -1015,68 +769,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracker"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5c98457ff700aaeefcd4a4a492096e78a2af1dd8523c66e94a3adb0fdbd415"
-dependencies = [
- "tracker-macros",
-]
-
-[[package]]
-name = "tracker-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19eb2373ccf3d1999967c26c3d44534ff71ae5d8b9dacf78f4b13132229e48"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "ublue-updater"
 version = "0.1.0"
 dependencies = [
  "futures",
  "gio",
+ "glib",
  "glib-build-tools",
  "gtk4",
  "inline-xml",
- "relm4",
- "relm4-components",
- "relm4-macros",
+ "libadwaita",
  "serde",
  "serde_json",
 ]
@@ -1094,84 +796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1181,70 +809,6 @@ checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ glib-build-tools = "0.21.0"
 
 [dependencies]
 futures = "0.3.31"
-gio = "0.21.2"
-
+gio = { version = "0.21.2", features = ["v2_84"] }
+adw = { version = "0.8.0", package = "libadwaita", features = ["v1_7"] }
 gtk = { version = "0.10.1", package = "gtk4", features = ["v4_18"] }
+glib = "0.21.3"
 inline-xml = "0.3.2"
-relm4 = { version = "0.10.0", package = "relm4", features = ["gnome_48", "libadwaita"] }
-relm4-components = "0.10.0"
-relm4-macros = "0.10.0"
+
+# relm4 = { version = "0.10.0", package = "relm4", features = ["gnome_48", "libadwaita"] }
+# relm4-components = "0.10.0"
+# relm4-macros = "0.10.0"
 
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Prototype gtk4 application to update the OS, flatpak, brew, etc, show a progress
 - ~~Port to libawaita~~
 - ~~Use `Clamp` to limit the size of the contents. See Deja Backup for an example.~~
 - ~~Rewrite the UI w/ relm4 for better async handling~~
+- ~~Rewrite to use gtk-rs (again)~~
+- Add support for `gettext`
+- Build flatpak
+- Write plugin system to update from various sources
+  - uupd
+  - bootc
+  - rpm-ostree
+  - flatpak
+  - brew
+  - distrobox
+- Re-add terminal output once plugin(s) are enabled and we can access the output from each plugin.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,25 @@
+use crate::modals;
+use adw::prelude::*;
+use gio::ActionEntry;
+
+/// Set the about action
+pub fn set_about(app: &adw::Application, window: &adw::ApplicationWindow) {
+    app.add_action_entries([ActionEntry::builder("about")
+        .activate(glib::clone!(
+            #[weak]
+            window,
+            move |_app: &adw::Application, _action, _parameter| {
+                modals::about::show(&window);
+            }
+        ))
+        .build()]);
+}
+
+/// Set the quit action
+pub fn set_quit(app: &adw::Application) {
+    app.add_action_entries([ActionEntry::builder("quit")
+        .activate(move |app: &adw::Application, _action, _parameter| {
+            app.quit();
+        })
+        .build()]);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,176 @@
+mod actions;
 mod config;
 mod modals;
 mod ui;
 mod utils;
 mod uupd;
 
-use relm4::*;
+use uupd::Progress;
 
-fn main() {
+use gtk::prelude::*;
+
+use std::cell::RefCell;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+
+fn main() -> glib::ExitCode {
     // Initialize our GSettings schema, if it doesn't exist
     utils::install_gsettings_schema();
 
+    // Create a new application
+    let application = adw::Application::builder()
+        .application_id(config::APP_ID)
+        .build();
+
+    application.connect_activate(|app| {
+        build_ui(app);
+    });
+
     // Run the application
-    RelmApp::new("com.github.AdamIsrael.UblueUpdater").run::<ui::App>("Ublue Updater".into());
+    application.run()
+}
+
+fn build_ui(app: &adw::Application) {
+    let header_bar = ui::get_header_bar();
+    let update_button = ui::get_update_button();
+    let progress_bar = ui::get_progress_bar();
+    let apply_check_button = ui::get_apply_check_button();
+
+    // Create cloned references because the closure will move them
+    let pbar = progress_bar.clone();
+    let apply = apply_check_button.clone();
+    let update = update_button.clone();
+
+    // Connect update button to run a system update command
+    update_button.connect_clicked(move |_| {
+        // Get the UI elements that the secondary thread needs to access
+        let ui_model = ui::UiModel {
+            apply_check_button: apply.clone(),
+            update_button: update.clone(),
+            progress_bar: pbar.clone(),
+        };
+
+        execute_command_async(ui_model);
+    });
+
+    let main_box = ui::get_main_container(
+        &header_bar,
+        &update_button,
+        &apply_check_button,
+        &progress_bar,
+    );
+    let window = ui::get_window(app, "UBlue Updater", main_box);
+
+    // Now that we have the window, connect the menu actions
+    actions::set_about(&app, &window);
+    actions::set_quit(&app);
+
+    // Present window
+    window.present();
+}
+
+fn execute_command_async(ui: ui::UiModel) {
+    // Disable the update button and checkbox while running uupd
+    ui.apply_check_button.set_sensitive(false);
+    ui.update_button.set_sensitive(false);
+    ui.progress_bar.set_visible(true);
+
+    let (tx, rx) = mpsc::channel();
+    GLOBAL.with(|global| {
+        *global.borrow_mut() = Some((ui, rx));
+    });
+
+    let cmd = "pkexec uupd --json".to_string();
+    if let Ok(child_process) = Command::new("sh")
+        .args(["-c", &cmd])
+        .stdout(Stdio::piped())
+        .spawn()
+    {
+        let incoming = child_process.stdout.unwrap();
+
+        let mut previous_overall = 0;
+
+        std::thread::spawn(move || {
+            let _ = &BufReader::new(incoming).lines().for_each(|line| {
+                let data = line.unwrap();
+                let mut p: Progress = serde_json::from_str(&data).unwrap();
+
+                p.previous_overall = previous_overall;
+
+                // Track the previous progress
+                previous_overall = p.overall;
+
+                // send data through channel
+                tx.send(p).unwrap();
+
+                // then tell the UI thread to read from that channel
+                glib::source::idle_add(|| {
+                    check_for_new_message();
+                    glib::ControlFlow::Break
+                });
+            });
+        });
+    }
+}
+
+// global variable to store the ui and an input channel
+// on the main thread only
+thread_local!(
+    static GLOBAL: RefCell<Option<(ui::UiModel, mpsc::Receiver<uupd::Progress>)>> =
+        const { RefCell::new(None) };
+);
+
+// function to check if a new message has been passed through the
+// global receiver and, if so, add it to the UI.
+fn check_for_new_message() {
+    GLOBAL.with(|global| {
+        if let Some((ui, rx)) = &*global.borrow() {
+            // Receive the Progress struct
+            let p: uupd::Progress = rx.recv().unwrap();
+
+            // Update the UI
+            let progress = if (p.progress + 1) < p.total {
+                p.progress + 1
+            } else {
+                p.progress
+            };
+            println!("Progress: {}/{}", progress, p.total);
+
+            let msg = format!(
+                "{} {} - {} (step {}/{})...",
+                p.msg,
+                p.title,
+                p.description,
+                progress,
+                p.total + 1
+            );
+            ui.progress_bar.set_text(Some(&msg));
+            ui.progress_bar
+                .set_fraction(p.previous_overall as f64 / 100.0);
+
+            let finished = p.progress == 0 && p.total == 0;
+
+            // If the progress is complete, re-enable the disabled UI elements
+            if finished {
+                ui.update_button.set_sensitive(true);
+                ui.apply_check_button.set_sensitive(true);
+                // ui.progress_bar.set_visible(false);
+
+                let reboot = ui.apply_check_button.is_active();
+
+                let msg = format!(
+                    "Update complete! {}",
+                    if reboot { "Rebooting..." } else { "" }
+                );
+                ui.progress_bar.set_text(Some(&msg));
+                ui.progress_bar.set_fraction(1.0);
+
+                if reboot && utils::check_reboot_needed() {
+                    utils::reboot_system();
+                }
+            }
+        }
+    });
 }

--- a/src/modals/about.rs
+++ b/src/modals/about.rs
@@ -1,49 +1,16 @@
-use adw::prelude::AdwDialogExt;
-use gtk::prelude::GtkApplicationExt;
-use relm4::{ComponentParts, ComponentSender, SimpleComponent, adw, gtk};
+use crate::config;
 
-use crate::config::VERSION;
+use adw::prelude::{AdwDialogExt, IsA};
 
-pub struct AboutDialog {}
+pub fn show(parent: &impl IsA<gtk::Widget>) {
+    let dialog = adw::AboutDialog::builder()
+        .application_icon(config::APP_ID)
+        .license_type(gtk::License::MitX11)
+        .website("https://github.com/AdamIsrael/ublue-updater/")
+        .issue_url("https://github.com/AdamIsrael/ublue-updater/issues")
+        .application_name("Ublue Updater")
+        .version(config::VERSION)
+        .build();
 
-impl SimpleComponent for AboutDialog {
-    type Init = ();
-    type Widgets = adw::AboutDialog;
-    type Input = ();
-    type Output = ();
-    type Root = adw::AboutDialog;
-
-    fn init_root() -> Self::Root {
-        adw::AboutDialog::builder()
-            // .application_icon(APP_ID)
-            // Insert your license of choice here
-            .license_type(gtk::License::MitX11)
-            // Insert your website here
-            .website("https://github.com/AdamIsrael/ublue-updater/")
-            // Insert your Issues page
-            .issue_url("https://github.com/AdamIsrael/ublue-updater/issues")
-            // Insert your application name here
-            .application_name("Ublue Updater")
-            .version(VERSION)
-            // .translator_credits("translator-credits")
-            .copyright("© 2025 Adam Israel")
-            .developers(vec!["Adam Israel"])
-            // .designers(vec!["Bilal Elmoussaoui"])
-            .build()
-    }
-
-    fn init(
-        _: Self::Init,
-        root: Self::Root,
-        _sender: ComponentSender<Self>,
-    ) -> ComponentParts<Self> {
-        let model = Self {};
-
-        let widgets = root.clone();
-        widgets.present(Some(&relm4::main_application().windows()[0]));
-
-        ComponentParts { model, widgets }
-    }
-
-    fn update_view(&self, _dialog: &mut Self::Widgets, _sender: ComponentSender<Self>) {}
+    dialog.present(Some(parent));
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,274 +1,110 @@
-use super::{config, utils, uupd};
-use crate::modals::about::AboutDialog;
+use super::config;
 
-use futures::FutureExt;
-use gtk::prelude::*;
-use gtk::{HeaderBar, gio, glib};
-use relm4::actions::{RelmAction, RelmActionGroup};
-use relm4::*;
+use adw::prelude::*;
+use gtk::{Box, Button, CheckButton, ProgressBar};
 
-use std::io::BufRead;
-use std::io::BufReader;
-use std::process::{Command, Stdio};
-
-#[derive(Default)]
-pub struct App {
-    /// Tracks if we're updating
-    updating: bool,
-
-    /// Track if we're rebooting after an OS upgrade
-    reboot: bool,
-
-    /// Contains output of a completed task.
-    task: Option<CmdOut>,
+// UiModel provides our worker thread with access to update the UI
+#[derive(Clone)]
+pub struct UiModel {
+    pub apply_check_button: CheckButton,
+    pub update_button: Button,
+    pub progress_bar: ProgressBar,
 }
 
-pub struct Widgets {
-    update: gtk::Button,
-    apply: gtk::CheckButton,
-    overall_progress: gtk::ProgressBar,
-}
+pub fn get_apply_check_button() -> CheckButton {
+    let settings = gio::Settings::new(config::APP_ID);
+    let reboot = settings.boolean("auto-reboot");
 
-impl Widgets {
-    fn save_apply(&self) -> Result<(), glib::BoolError> {
+    let cb = CheckButton::builder()
+        .label("Auto-reboot if the OS image is updated?")
+        .margin_start(12)
+        .margin_end(12)
+        .active(reboot)
+        .build();
+
+    cb.connect_toggled(|button| {
+        // Update the model when the button is toggled
         let settings = gio::Settings::new(config::APP_ID);
+        if let Err(err) = settings.set_boolean("auto-reboot", button.is_active()) {
+            eprintln!("Failed to set auto-reboot setting: {}", err);
+        }
+    });
 
-        settings.set_boolean("auto-reboot", self.apply.is_active())?;
-
-        Ok(())
-    }
-
-    fn load_apply(&self) {
-        let settings = gio::Settings::new(config::APP_ID);
-
-        let reboot = settings.boolean("auto-reboot");
-        self.apply.set_active(reboot);
-    }
+    cb
 }
 
-#[derive(Debug)]
-pub enum Input {
-    Update,
-    Apply,
+pub fn get_progress_bar() -> ProgressBar {
+    ProgressBar::builder()
+        .margin_top(12)
+        .margin_bottom(6)
+        .margin_start(12)
+        .margin_end(12)
+        .show_text(true)
+        .text("")
+        .visible(false)
+        .build()
 }
 
-#[derive(Debug)]
-pub enum Output {}
-
-// {"msg":"Updating","title":"System","description":"rpm-ostree","progress":0,"total":5,"step_progress":0,"overall":17}
-#[derive(Debug, Clone)]
-pub enum CmdOut {
-    /// Progress update from a command.
-    Json(uupd::Progress, u32),
-    /// The final output of the command.
-    Finished,
+pub fn get_update_button() -> Button {
+    Button::builder()
+        .label("Update")
+        .margin_top(12)
+        .margin_bottom(6)
+        .margin_start(12)
+        .margin_end(12)
+        .build()
 }
 
-impl Component for App {
-    type Init = String;
-    type Input = Input;
-    type Output = Output;
-    type CommandOutput = CmdOut;
-    type Widgets = Widgets;
-    type Root = gtk::Window;
+pub fn get_header_bar() -> adw::HeaderBar {
+    let header_bar = adw::HeaderBar::new();
+    let window_title = adw::WindowTitle::builder().title("Ublue Updater").build();
 
-    fn init_root() -> Self::Root {
-        gtk::Window::default()
-    }
+    let main_menu = gio::Menu::new();
+    main_menu.append(Some("About"), Some("app.about"));
+    main_menu.append(Some("Quit"), Some("app.quit"));
 
-    fn init(
-        _args: Self::Init,
-        root: Self::Root,
-        sender: ComponentSender<Self>,
-    ) -> ComponentParts<Self> {
-        relm4::new_action_group!(pub(super) WindowActionGroup, "win");
-        relm4::new_stateless_action!(AboutAction, WindowActionGroup, "about");
+    let mb = gtk::MenuButton::new();
+    mb.set_icon_name("open-menu-symbolic");
+    mb.set_menu_model(Some(&main_menu));
+    header_bar.pack_end(&mb);
 
-        relm4_macros::menu! {
-            main_menu: {
-                "About" => AboutAction,
-            }
-        };
+    header_bar.set_title_widget(Some(&window_title));
+    header_bar
+}
 
-        relm4::view! {
-            container = gtk::Box {
-                set_halign: gtk::Align::Center,
-                set_valign: gtk::Align::Center,
-                set_width_request: 300,
-                set_spacing: 12,
-                set_margin_top: 4,
-                set_margin_bottom: 4,
-                set_margin_start: 12,
-                set_margin_end: 12,
-                set_orientation: gtk::Orientation::Horizontal,
+pub fn get_main_container(
+    header_bar: &adw::HeaderBar,
+    update_button: &Button,
+    apply_check_button: &CheckButton,
+    progress_bar: &ProgressBar,
+) -> Box {
+    // Create main container
+    let parent = Box::new(gtk::Orientation::Vertical, 6);
 
-                gtk::Box {
-                    set_spacing: 4,
-                    set_hexpand: true,
-                    set_valign: gtk::Align::Center,
-                    set_orientation: gtk::Orientation::Vertical,
+    parent.append(header_bar);
 
-                    append: update = &gtk::Button {
-                        set_label: "Update",
-                        connect_clicked => Input::Update,
-                    },
+    let main_box = Box::new(gtk::Orientation::Vertical, 6);
 
-                    append: apply = &gtk::CheckButton {
-                        set_label: Some("Auto-reboot if the OS image is updated?"),
-                        connect_toggled => Input::Apply,
-                    },
+    main_box.append(update_button);
+    main_box.append(apply_check_button);
+    main_box.append(progress_bar);
 
-                    append: overall_progress = &gtk::ProgressBar {
-                        set_visible: false,
-                        set_show_text: true,
-                    }
-                },
-            }
-        }
-
-        // Build a new HeaderBar to access the menu
-        let hbar = HeaderBar::new();
-        let mb = gtk::MenuButton::new();
-        mb.set_icon_name("open-menu-symbolic");
-        mb.set_menu_model(Some(&main_menu));
-        hbar.pack_end(&mb);
-        root.set_titlebar(Some(&hbar));
-
-        root.set_child(Some(&container));
-
-        let widgets = Widgets {
-            update,
-            apply,
-            overall_progress,
-        };
-
-        // Wire up the menu actions
-        let mut actions = RelmActionGroup::<WindowActionGroup>::new();
-        let about_action = {
-            RelmAction::<AboutAction>::new_stateless(move |_| {
-                AboutDialog::builder().launch(()).detach();
-            })
-        };
-        actions.add_action(about_action);
-        actions.register_for_widget(&root);
-
-        widgets.load_apply();
-
-        ComponentParts {
-            model: App::default(),
-            widgets: widgets,
-        }
-    }
-
-    fn shutdown(&mut self, widgets: &mut Self::Widgets, _output: relm4::Sender<Self::Output>) {
-        widgets.save_apply().unwrap();
-    }
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
-        match message {
-            Input::Apply => {
-                if !self.updating {
-                    self.reboot = !self.reboot;
-                }
-            }
-            Input::Update => {
-                self.updating = true;
-
-                sender.command(|out, shutdown| {
-                    shutdown
-                        // Performs this operation until a shutdown is triggered
-                        .register(async move {
-                            let cmd = "pkexec uupd --json".to_string();
-                            if let Ok(child_process) = Command::new("sh")
-                                .args(["-c", &cmd])
-                                .stdout(Stdio::piped())
-                                .spawn()
-                            {
-                                let incoming = child_process.stdout.unwrap();
-                                let mut previous_overall = 0;
-
-                                let _ = &BufReader::new(incoming).lines().for_each(|line| {
-                                    let data = line.unwrap();
-                                    // println!("{}", data);
-                                    let p: uupd::Progress = serde_json::from_str(&data).unwrap();
-
-                                    // There'll be no progress or total on the last message
-                                    let finished = p.progress == 0 && p.total == 0;
-                                    if !finished {
-                                        out.send(CmdOut::Json(p.clone(), previous_overall))
-                                            .unwrap();
-                                        previous_overall = p.overall;
-                                    } else {
-                                        out.send(CmdOut::Finished).unwrap();
-                                    }
-                                });
-                            }
-                        })
-                        // Perform task until a shutdown interrupts it
-                        .drop_on_shutdown()
-                        // Wrap into a `Pin<Box<Future>>` for return
-                        .boxed()
-                });
-            }
-        }
-    }
-
-    fn update_cmd(
-        &mut self,
-        message: Self::CommandOutput,
-        _sender: ComponentSender<Self>,
-        _root: &Self::Root,
-    ) {
-        if let CmdOut::Finished = message {
-            self.updating = false;
-            if self.reboot && utils::check_reboot_needed() {
-                // I'm not sure if this is helping or not, tbh, but I can only test once/day.
-                std::thread::sleep(std::time::Duration::from_secs(3));
-
-                utils::reboot_system();
-            }
-        }
-        self.task = Some(message);
-    }
-
-    fn update_view(&self, widgets: &mut Self::Widgets, _sender: ComponentSender<Self>) {
-        widgets.update.set_sensitive(!self.updating);
-        widgets.apply.set_sensitive(!self.updating);
-
-        if let Some(ref progress) = self.task {
-            match progress {
-                CmdOut::Json(received, previous_overall) => {
-                    // println!("{:?}", received);
-
-                    let progress = if (received.progress + 1) < received.total {
-                        received.progress + 1
-                    } else {
-                        received.progress
-                    };
-
-                    let msg = format!(
-                        "{} {} - {} (step {}/{})...",
-                        received.msg,
-                        received.title,
-                        received.description,
-                        progress,
-                        received.total + 1
-                    );
-
-                    widgets.overall_progress.set_text(Some(&msg));
-                    widgets.overall_progress.set_visible(true);
-                    widgets
-                        .overall_progress
-                        .set_fraction(*previous_overall as f64 / 100.0);
-                }
-                CmdOut::Finished => {
-                    let msg = format!(
-                        "Update complete! {}",
-                        if self.reboot { "Rebooting..." } else { "" }
-                    );
-                    widgets.overall_progress.set_text(Some(&msg));
-                    widgets.overall_progress.set_fraction(1.0);
-                }
-            }
-        }
-    }
+    let clamp = adw::Clamp::builder()
+        .child(&main_box)
+        .maximum_size(500)
+        .tightening_threshold(10)
+        // .unit(adw::ClampUnit::Pixels::new(10))
+        .build();
+    parent.append(&clamp);
+    parent
+}
+pub fn get_window(app: &adw::Application, title: &str, main_box: Box) -> adw::ApplicationWindow {
+    // Create window
+    adw::ApplicationWindow::builder()
+        .application(app)
+        .title(title)
+        .resizable(false)
+        .width_request(300)
+        .content(&main_box)
+        .build()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use inline_xml::xml;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Installs our GSettings schema, if they're not already installed.
 pub fn install_gsettings_schema() {
@@ -44,6 +44,8 @@ pub fn check_reboot_needed() -> bool {
     let cmd = "rpm-ostree status --pending-exit-77";
     let rc = Command::new("sh")
         .args(["-c", cmd])
+        // pipe stdout to /dev/null for now. Otherwise it goes to this app's stdout
+        .stdout(Stdio::null())
         .status()
         .expect("Failed to execute command");
     rc.code() == Some(77)

--- a/src/uupd.rs
+++ b/src/uupd.rs
@@ -12,6 +12,9 @@ pub struct Progress {
     pub description: String,
 
     #[serde(default)]
+    pub previous_overall: u32,
+
+    #[serde(default)]
     pub progress: u32,
 
     #[serde(default)]


### PR DESCRIPTION
Use the `gtk4` crate directly rather than `relm4`. Debugging `relm4`'s macros were a pain, even with `cargo expand`.

This re-enables the gtk4 interface, with the improvements backported in.